### PR TITLE
Config to exclude bridging header

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ As an example you can have a look at this [plugin](https://github.com/akofman/co
 
 If the `cordova-plugin-add-swift-support` plugin is already installed to your project, then you can add your own Swift plugin as usual, its prefixed Bridging-Header will be automatically found and merged.
 
+If you have some targets in your project that don't need support for a bridging header (e.g. watch app written completely in Swift), you can configure excluded targets in a comma-separated list as follows:
+
+`<preference name="SwiftOnlyTargets" value="WatchExtension,TodayExtension" />`
+
 ## Contributing
 
 The src folder contains ECMAScript 2015 source files, the minimum Node.js version is `6` (Boron).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ As an example you can have a look at this [plugin](https://github.com/akofman/co
 
 If the `cordova-plugin-add-swift-support` plugin is already installed to your project, then you can add your own Swift plugin as usual, its prefixed Bridging-Header will be automatically found and merged.
 
-If you have some targets in your project that don't need support for a bridging header (e.g. watch app written completely in Swift), you can configure excluded targets in a comma-separated list as follows:
+If you have some targets in your project that don't need support for a bridging header (e.g. watch app written completely in Swift with no Objective-C dependencies), you can configure excluded targets in a comma-separated list as follows:
 
 `<preference name="SwiftOnlyTargets" value="WatchExtension,TodayExtension" />`
 

--- a/src/add-swift-support.js
+++ b/src/add-swift-support.js
@@ -86,12 +86,23 @@ module.exports = context => {
 
       const bridgingHeaderProperty = '"$(PROJECT_DIR)/$(PROJECT_NAME)' + bridgingHeaderPath.split(projectPath)[1] + '"';
 
+      let swiftOnlyTargets = config.getPreference('SwiftOnlyTargets', 'ios') || [];
+      let swiftOnlyProducts = [];
+      if (swiftOnlyTargets) {
+        swiftOnlyProducts = swiftOnlyTargets.split(',').map((i) => '"' + i + '"'); // product names are quoted
+      }
+
       for (configName in buildConfigs) {
         if (!COMMENT_KEY.test(configName)) {
           buildConfig = buildConfigs[configName];
-          if (xcodeProject.getBuildProperty('SWIFT_OBJC_BRIDGING_HEADER', buildConfig.name) !== bridgingHeaderProperty) {
-            xcodeProject.updateBuildProperty('SWIFT_OBJC_BRIDGING_HEADER', bridgingHeaderProperty, buildConfig.name);
-            console.log('Update IOS build setting SWIFT_OBJC_BRIDGING_HEADER to:', bridgingHeaderProperty, 'for build configuration', buildConfig.name);
+          if (getBuildProperty('SWIFT_OBJC_BRIDGING_HEADER', buildConfig) !== bridgingHeaderProperty) {
+            let productName = getBuildProperty('PRODUCT_NAME', buildConfig);
+            if (productName && swiftOnlyProducts.includes(productName)) {
+              console.log('Will not set SWIFT_OBJC_BRIDGING_HEADER for', productName);
+            } else {
+              updateBuildProperty('SWIFT_OBJC_BRIDGING_HEADER', bridgingHeaderProperty, buildConfig);
+              console.log('Update IOS build setting SWIFT_OBJC_BRIDGING_HEADER to:', bridgingHeaderProperty, 'for build configuration', buildConfig.name);
+            }
           }
         }
       }


### PR DESCRIPTION
Bridging header is not needed for some targets--such as watch or widget--as they can be written completely in Swift with no dependencies on Objective-C. This PR adds ability for config value to specify these types of targets so the bridging header is not added for them.